### PR TITLE
Support arguments for Actions and Conditions

### DIFF
--- a/src/decorators/decorator.js
+++ b/src/decorators/decorator.js
@@ -2,13 +2,17 @@
  * A base node decorator.
  * @param type The node decorator type.
  */
-export default function Decorator(type) {
-  
+export default function Decorator(type, args) {
+    /**
+     * Gets the arguments
+    */
+    this.getArguments = () => args || [];
+
     /**
      * Gets the type of the node.
      */
     this.getType = () => type;
-  
+
     /**
      * Gets whether the decorator is a guard.
      */

--- a/src/decorators/entry.js
+++ b/src/decorators/entry.js
@@ -4,8 +4,8 @@ import Decorator from './decorator'
  * An ENTRY decorator which defines a blackboard function to call when the decorated node is updated and moves out of running state.
  * @param functionName The name of the blackboard function to call.
  */
-export default function Entry(functionName, ...args) {
-    Decorator.call(this, "entry");
+export default function Entry(functionName, args) {
+    Decorator.call(this, "entry", args);
 
     /**
      * Gets the function name.
@@ -20,7 +20,7 @@ export default function Entry(functionName, ...args) {
             type: this.getType(),
             isGuard: this.isGuard(),
             functionName: this.getFunctionName(),
-            arguments: args
+            arguments: this.getArguments()
         };
     };
 
@@ -31,7 +31,7 @@ export default function Entry(functionName, ...args) {
     this.callBlackboardFunction = (board) => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].apply(board, args || []);
+            board[functionName].apply(board, this.getArguments());
         } else {
             throw `cannot call entry decorator function '${functionName}' is not defined in the blackboard`;
         }

--- a/src/decorators/entry.js
+++ b/src/decorators/entry.js
@@ -4,7 +4,7 @@ import Decorator from './decorator'
  * An ENTRY decorator which defines a blackboard function to call when the decorated node is updated and moves out of running state.
  * @param functionName The name of the blackboard function to call.
  */
-export default function Entry(functionName) {
+export default function Entry(functionName, ...args) {
     Decorator.call(this, "entry");
 
     /**
@@ -19,7 +19,8 @@ export default function Entry(functionName) {
         return {
             type: this.getType(),
             isGuard: this.isGuard(),
-            functionName: this.getFunctionName()
+            functionName: this.getFunctionName(),
+            arguments: args
         };
     };
 
@@ -30,7 +31,7 @@ export default function Entry(functionName) {
     this.callBlackboardFunction = (board) => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].call(board);
+            board[functionName].apply(board, args || []);
         } else {
             throw `cannot call entry decorator function '${functionName}' is not defined in the blackboard`;
         }

--- a/src/decorators/exit.js
+++ b/src/decorators/exit.js
@@ -4,8 +4,8 @@ import Decorator from './decorator'
  * An EXIT decorator which defines a blackboard function to call when the decorated node is updated and moves to a finished state or is aborted.
  * @param functionName The name of the blackboard function to call.
  */
-export default function Exit(functionName, ...args) {
-    Decorator.call(this, "exit");
+export default function Exit(functionName, args) {
+    Decorator.call(this, "exit", args);
 
     /**
      * Gets the function name.
@@ -20,7 +20,7 @@ export default function Exit(functionName, ...args) {
             type: this.getType(),
             isGuard: this.isGuard(),
             functionName: this.getFunctionName(),
-            arguments: args || []
+            arguments: this.getArguments()
         };
     };
 
@@ -33,10 +33,10 @@ export default function Exit(functionName, ...args) {
     this.callBlackboardFunction = (board, isSuccess, isAborted) => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].call(board, 
-                                     { succeeded: isSuccess, aborted: isAborted },
-                                     ...(args || [])
-                                    );
+            board[functionName].apply(board,
+                [{ succeeded: isSuccess, aborted: isAborted }]
+                    .concat(this.getArguments())
+            );
         } else {
             throw `cannot call exit decorator function '${functionName}' is not defined in the blackboard`;
         }

--- a/src/decorators/exit.js
+++ b/src/decorators/exit.js
@@ -20,7 +20,7 @@ export default function Exit(functionName, ...args) {
             type: this.getType(),
             isGuard: this.isGuard(),
             functionName: this.getFunctionName(),
-            arguments: args
+            arguments: args || []
         };
     };
 
@@ -33,10 +33,10 @@ export default function Exit(functionName, ...args) {
     this.callBlackboardFunction = (board, isSuccess, isAborted) => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].apply(board, [
-                { succeeded: isSuccess, aborted: isAborted },
-                ...(args || [])
-            ]);
+            board[functionName].call(board, 
+                                     { succeeded: isSuccess, aborted: isAborted },
+                                     ...(args || [])
+                                    );
         } else {
             throw `cannot call exit decorator function '${functionName}' is not defined in the blackboard`;
         }

--- a/src/decorators/exit.js
+++ b/src/decorators/exit.js
@@ -4,7 +4,7 @@ import Decorator from './decorator'
  * An EXIT decorator which defines a blackboard function to call when the decorated node is updated and moves to a finished state or is aborted.
  * @param functionName The name of the blackboard function to call.
  */
-export default function Exit(functionName) {
+export default function Exit(functionName, ...args) {
     Decorator.call(this, "exit");
 
     /**
@@ -19,7 +19,8 @@ export default function Exit(functionName) {
         return {
             type: this.getType(),
             isGuard: this.isGuard(),
-            functionName: this.getFunctionName()
+            functionName: this.getFunctionName(),
+            arguments: args
         };
     };
 
@@ -32,7 +33,10 @@ export default function Exit(functionName) {
     this.callBlackboardFunction = (board, isSuccess, isAborted) => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].call(board, { succeeded: isSuccess, aborted: isAborted });
+            board[functionName].apply(board, [
+                { succeeded: isSuccess, aborted: isAborted },
+                ...(args || [])
+            ]);
         } else {
             throw `cannot call exit decorator function '${functionName}' is not defined in the blackboard`;
         }

--- a/src/decorators/guards/until.js
+++ b/src/decorators/guards/until.js
@@ -4,8 +4,8 @@ import Decorator from '../decorator'
  * An UNTIL guard which is satisfied as long as the given condition remains false.
  * @param condition The name of the condition function that determines whether the guard is satisfied.
  */
-export default function Until(condition, ...args) {
-    Decorator.call(this, "until");
+export default function Until(condition, args) {
+    Decorator.call(this, "until", args);
 
     /**
      * Gets whether the decorator is a guard.
@@ -25,7 +25,7 @@ export default function Until(condition, ...args) {
             type: this.getType(),
             isGuard: this.isGuard(),
             condition: this.getCondition(),
-            arguments: args
+            arguments: this.getArguments()
         };
     };
 
@@ -37,7 +37,7 @@ export default function Until(condition, ...args) {
     this.isSatisfied = (board) => {
         // Call the condition function to determine whether this guard is satisfied.
         if (typeof board[condition] === "function") {
-            return !!!(board[condition].apply(board, args || []));
+            return !!!(board[condition].apply(board, this.getArguments()));
         } else {
             throw `cannot evaluate node guard as function '${condition}' is not defined in the blackboard`;
         }

--- a/src/decorators/guards/until.js
+++ b/src/decorators/guards/until.js
@@ -4,7 +4,7 @@ import Decorator from '../decorator'
  * An UNTIL guard which is satisfied as long as the given condition remains false.
  * @param condition The name of the condition function that determines whether the guard is satisfied.
  */
-export default function Until(condition) {
+export default function Until(condition, ...args) {
     Decorator.call(this, "until");
 
     /**
@@ -24,7 +24,8 @@ export default function Until(condition) {
         return {
             type: this.getType(),
             isGuard: this.isGuard(),
-            condition: this.getCondition()
+            condition: this.getCondition(),
+            arguments: args
         };
     };
 
@@ -36,7 +37,7 @@ export default function Until(condition) {
     this.isSatisfied = (board) => {
         // Call the condition function to determine whether this guard is satisfied.
         if (typeof board[condition] === "function") {
-            return !!!(board[condition].call(board));
+            return !!!(board[condition].apply(board, args || []));
         } else {
             throw `cannot evaluate node guard as function '${condition}' is not defined in the blackboard`;
         }

--- a/src/decorators/guards/while.js
+++ b/src/decorators/guards/while.js
@@ -5,7 +5,7 @@ import Decorator from '../decorator'
  * @param condition The name of the condition function that determines whether the guard is satisfied.
  */
 export default function While(condition, ...args) {
-    Decorator.call(this, "while");
+    Decorator.call(this, "while", args);
 
     /**
      * Gets whether the decorator is a guard.
@@ -25,7 +25,7 @@ export default function While(condition, ...args) {
             type: this.getType(),
             isGuard: this.isGuard(),
             condition: this.getCondition(),
-            arguments: args
+            arguments: this.getArguments()
         };
     };
 
@@ -37,7 +37,7 @@ export default function While(condition, ...args) {
     this.isSatisfied = (board) => {
         // Call the condition function to determine whether this guard is satisfied.
         if (typeof board[condition] === "function") {
-            return !!(board[condition].apply(board, args || []));
+            return !!(board[condition].apply(board, this.getArguments()));
         } else {
             throw `cannot evaluate node guard as function '${condition}' is not defined in the blackboard`;
         }

--- a/src/decorators/guards/while.js
+++ b/src/decorators/guards/while.js
@@ -4,7 +4,7 @@ import Decorator from '../decorator'
  * A WHILE guard which is satisfied as long as the given condition remains true.
  * @param condition The name of the condition function that determines whether the guard is satisfied.
  */
-export default function While(condition) {
+export default function While(condition, ...args) {
     Decorator.call(this, "while");
 
     /**
@@ -24,7 +24,8 @@ export default function While(condition) {
         return {
             type: this.getType(),
             isGuard: this.isGuard(),
-            condition: this.getCondition()
+            condition: this.getCondition(),
+            arguments: args
         };
     };
 
@@ -36,7 +37,7 @@ export default function While(condition) {
     this.isSatisfied = (board) => {
         // Call the condition function to determine whether this guard is satisfied.
         if (typeof board[condition] === "function") {
-            return !!(board[condition].call(board));
+            return !!(board[condition].apply(board, args || []));
         } else {
             throw `cannot evaluate node guard as function '${condition}' is not defined in the blackboard`;
         }

--- a/src/decorators/step.js
+++ b/src/decorators/step.js
@@ -4,7 +4,7 @@ import Decorator from './decorator'
  * A STEP decorator which defines a blackboard function to call when the decorated node is updated.
  * @param functionName The name of the blackboard function to call.
  */
-export default function Step(functionName) {
+export default function Step(functionName, ...args) {
     Decorator.call(this, "step");
 
     /**
@@ -19,7 +19,8 @@ export default function Step(functionName) {
         return {
             type: this.getType(),
             isGuard: this.isGuard(),
-            functionName: this.getFunctionName()
+            functionName: this.getFunctionName(),
+            arguments: args
         };
     };
 
@@ -30,7 +31,7 @@ export default function Step(functionName) {
     this.callBlackboardFunction = (board) => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].call(board);
+            board[functionName].apply(board, args || []);
         } else {
             throw `cannot call entry decorator function '${functionName}' is not defined in the blackboard`;
         }

--- a/src/decorators/step.js
+++ b/src/decorators/step.js
@@ -4,8 +4,8 @@ import Decorator from './decorator'
  * A STEP decorator which defines a blackboard function to call when the decorated node is updated.
  * @param functionName The name of the blackboard function to call.
  */
-export default function Step(functionName, ...args) {
-    Decorator.call(this, "step");
+export default function Step(functionName, args) {
+    Decorator.call(this, "step", args);
 
     /**
      * Gets the function name.
@@ -20,7 +20,7 @@ export default function Step(functionName, ...args) {
             type: this.getType(),
             isGuard: this.isGuard(),
             functionName: this.getFunctionName(),
-            arguments: args
+            arguments: this.getArguments()
         };
     };
 
@@ -31,7 +31,7 @@ export default function Step(functionName, ...args) {
     this.callBlackboardFunction = (board) => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].apply(board, args || []);
+            board[functionName].apply(board, this.getArguments());
         } else {
             throw `cannot call entry decorator function '${functionName}' is not defined in the blackboard`;
         }

--- a/src/nodes/action.js
+++ b/src/nodes/action.js
@@ -7,7 +7,7 @@ import State from "../state";
  * @param decorators The node decorators.
  * @param actionName The action name.
  */
-export default function Action(decorators, actionName) {
+export default function Action(decorators, actionName, actionArguments) {
     Leaf.call(this, "action", decorators);
 
     /**
@@ -48,7 +48,7 @@ export default function Action(decorators, actionName) {
         // - The finished state of this action node.
         // - A promise to return a finished node state.
         // - Undefined if the node should remain in the running state.
-        const updateResult = action.call(board);
+        const updateResult = action.call(board, actionArguments || []);
 
         if (updateResult instanceof Promise) {
             updateResult.then(

--- a/src/nodes/action.js
+++ b/src/nodes/action.js
@@ -11,7 +11,7 @@ export default function Action(decorators, actionName, actionArguments) {
     Leaf.call(this, "action", decorators);
 
     /**
-     * Whether there is a pending update promise. 
+     * Whether there is a pending update promise.
      */
     let isUsingUpdatePromise = false;
 
@@ -19,7 +19,7 @@ export default function Action(decorators, actionName, actionArguments) {
      * The finished state result of an update promise.
      */
     let updatePromiseStateResult = null;
-   
+
     /**
      * Update the node.
      * @param board The board.
@@ -37,7 +37,7 @@ export default function Action(decorators, actionName, actionArguments) {
                 // Set the state of this node to match the state returned by the promise.
                 this.setState(updatePromiseStateResult);
             }
-            
+
             return;
         }
 
@@ -48,7 +48,7 @@ export default function Action(decorators, actionName, actionArguments) {
         // - The finished state of this action node.
         // - A promise to return a finished node state.
         // - Undefined if the node should remain in the running state.
-        const updateResult = action.call(board, actionArguments || []);
+        const updateResult = action.apply(board, actionArguments || []);
 
         if (updateResult instanceof Promise) {
             updateResult.then(
@@ -65,7 +65,7 @@ export default function Action(decorators, actionName, actionArguments) {
 
                     // Set pending update promise state result to be processed on next update.
                     updatePromiseStateResult = result;
-                }, 
+                },
                 (reason) => {
                     // If 'isUpdatePromisePending' is null then the promise was cleared as it was resolving, probably via an abort of reset.
                     if (!isUsingUpdatePromise) {

--- a/src/nodes/condition.js
+++ b/src/nodes/condition.js
@@ -7,7 +7,7 @@ import State from "../state";
  * @param decorators The node decorators.
  * @param condition The name of the condition function. 
  */
-export default function Condition(decorators, condition) {
+export default function Condition(decorators, condition, conditionArguments) {
     Leaf.call(this, "condition", decorators);
    
     /**
@@ -18,7 +18,7 @@ export default function Condition(decorators, condition) {
     this.onUpdate = function(board) {
         // Call the condition function to determine the state of this node, but it must exist in the blackboard.
         if (typeof board[condition] === "function") {
-            this.setState(!!(board[condition].call(board)) ? State.SUCCEEDED : State.FAILED);
+            this.setState(!!(board[condition].call(board, conditionArguments || [])) ? State.SUCCEEDED : State.FAILED);
         } else {
             throw `cannot update condition node as function '${condition}' is not defined in the blackboard`;
         }

--- a/src/nodes/condition.js
+++ b/src/nodes/condition.js
@@ -5,11 +5,11 @@ import State from "../state";
  * A Condition leaf node.
  * This will succeed or fail immediately based on a board predicate, without moving to the 'RUNNING' state.
  * @param decorators The node decorators.
- * @param condition The name of the condition function. 
+ * @param condition The name of the condition function.
  */
 export default function Condition(decorators, condition, conditionArguments) {
     Leaf.call(this, "condition", decorators);
-   
+
     /**
      * Update the node.
      * @param board The board.
@@ -18,7 +18,11 @@ export default function Condition(decorators, condition, conditionArguments) {
     this.onUpdate = function(board) {
         // Call the condition function to determine the state of this node, but it must exist in the blackboard.
         if (typeof board[condition] === "function") {
-            this.setState(!!(board[condition].call(board, conditionArguments || [])) ? State.SUCCEEDED : State.FAILED);
+            this.setState(
+                !!(board[condition].apply(board, conditionArguments || []))
+                    ? State.SUCCEEDED
+                    : State.FAILED
+            );
         } else {
             throw `cannot update condition node as function '${condition}' is not defined in the blackboard`;
         }

--- a/src/rootASTNodesBuilder.js
+++ b/src/rootASTNodesBuilder.js
@@ -209,7 +209,7 @@ const ASTNodeFactories = {
             return new Condition(
                 this.decorators,
                 this.conditionFunction,
-		this.conditionArguments
+                this.conditionArguments
             );
         }
     }),
@@ -426,9 +426,9 @@ export default function buildRootASTNodes(tokens) {
                 }
 
                 // The condition name will be defined as a node argument.
-                const tokenArguments = getArguments(tokens);
-                node.conditionFunction = tokenArguments.pop();
-                node.conditionArguments = tokenArguments || [];
+                const conditionArguments = getArguments(tokens);
+                node.conditionFunction = conditionArguments.pop();
+                node.conditionArguments = conditionArguments;
 
                 // Try to pick any decorators off of the token stack.
                 node.decorators = getDecorators(tokens);
@@ -525,9 +525,9 @@ export default function buildRootASTNodes(tokens) {
                 }
 
                 // The action name will be defined as a node argument.
-                const tokenArguments = getArguments(tokens);
-                node.actionName = tokenArguments.pop();
-                node.actionArguments = tokenArguments || [];
+                const actionArguments = getArguments(tokens);
+                node.actionName = actionArguments.pop();
+                node.actionArguments = actionArguments;
 
                 // Try to pick any decorators off of the token stack.
                 node.decorators = getDecorators(tokens);

--- a/src/rootASTNodesBuilder.js
+++ b/src/rootASTNodesBuilder.js
@@ -18,11 +18,11 @@ import Step from './decorators/step'
  * The node decorator factories.
  */
 const DecoratorFactories = {
-    "WHILE": (condition) => new While(condition),
-    "UNTIL": (condition) => new Until(condition),
-    "ENTRY": (functionName) => new Entry(functionName),
-    "EXIT": (functionName) => new Exit(functionName),
-    "STEP": (functionName) => new Step(functionName)
+    "WHILE": (condition, ...args) => new While(condition, ...args),
+    "UNTIL": (condition, ...args) => new Until(condition, ...args),
+    "ENTRY": (functionName, ...args) => new Entry(functionName, ...args),
+    "EXIT": (functionName, ...args) => new Exit(functionName, ...args),
+    "STEP": (functionName, ...args) => new Step(functionName, ...args)
 };
 
 /**

--- a/src/rootASTNodesBuilder.js
+++ b/src/rootASTNodesBuilder.js
@@ -18,18 +18,18 @@ import Step from './decorators/step'
  * The node decorator factories.
  */
 const DecoratorFactories = {
-    "WHILE": (condition, ...args) => new While(condition, ...args),
-    "UNTIL": (condition, ...args) => new Until(condition, ...args),
-    "ENTRY": (functionName, ...args) => new Entry(functionName, ...args),
-    "EXIT": (functionName, ...args) => new Exit(functionName, ...args),
-    "STEP": (functionName, ...args) => new Step(functionName, ...args)
+    "WHILE": (condition, args) => new While(condition, args),
+    "UNTIL": (condition, args) => new Until(condition, args),
+    "ENTRY": (functionName, args) => new Entry(functionName, args),
+    "EXIT": (functionName, args) => new Exit(functionName, args),
+    "STEP": (functionName, args) => new Step(functionName, args)
 };
 
 /**
  * The AST node factories.
  */
 const ASTNodeFactories = {
-    "ROOT": () => ({ 
+    "ROOT": () => ({
         type: "root",
         decorators: [],
         name: null,
@@ -45,14 +45,14 @@ const ASTNodeFactories = {
                 throw "a root node must have a single child";
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Root(
                 this.decorators,
                 this.children[0].createNodeInstance(namedRootNodeProvider, visitedBranches.slice())
             );
         }
     }),
-    "BRANCH": () => ({ 
+    "BRANCH": () => ({
         type: "branch",
         branchName: "",
         validate: function (depth) {},
@@ -83,7 +83,7 @@ const ASTNodeFactories = {
                 throw "a selector node must have at least a single child";
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Selector(
                 this.decorators,
                 this.children.map((child) => child.createNodeInstance(namedRootNodeProvider, visitedBranches.slice()))
@@ -93,14 +93,14 @@ const ASTNodeFactories = {
     "SEQUENCE": () => ({
         type: "sequence",
         decorators: [],
-        children: [], 
+        children: [],
         validate: function (depth) {
             // A sequence node must have at least a single node.
             if (this.children.length < 1) {
                 throw "a sequence node must have at least a single child";
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Sequence(
                 this.decorators,
                 this.children.map((child) => child.createNodeInstance(namedRootNodeProvider, visitedBranches.slice()))
@@ -110,14 +110,14 @@ const ASTNodeFactories = {
     "PARALLEL": () => ({
         type: "parallel",
         decorators: [],
-        children: [], 
+        children: [],
         validate: function (depth) {
             // A parallel node must have at least a single node.
             if (this.children.length < 1) {
                 throw "a parallel node must have at least a single child";
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Parallel(
                 this.decorators,
                 this.children.map((child) => child.createNodeInstance(namedRootNodeProvider, visitedBranches.slice()))
@@ -128,14 +128,14 @@ const ASTNodeFactories = {
         type: "lotto",
         decorators: [],
         children: [],
-        tickets: [], 
+        tickets: [],
         validate: function (depth) {
             // A lotto node must have at least a single node.
             if (this.children.length < 1) {
                 throw "a lotto node must have at least a single child";
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Lotto(
                 this.decorators,
                 this.tickets,
@@ -155,14 +155,14 @@ const ASTNodeFactories = {
                 throw "a repeat node must have a single child";
             }
 
-            // A repeat node must have a positive number of iterations if defined. 
+            // A repeat node must have a positive number of iterations if defined.
             if (this.iterations !== null && this.iterations < 0) {
                 throw "a repeat node must have a positive number of iterations if defined";
             }
 
             // There is validation to carry out if a longest duration was defined.
             if (this.maximumIterations !== null) {
-                // A repeat node must have a positive maximum iterations count if defined. 
+                // A repeat node must have a positive maximum iterations count if defined.
                 if (this.maximumIterations < 0) {
                     throw "a repeat node must have a positive maximum iterations count if defined";
                 }
@@ -173,7 +173,7 @@ const ASTNodeFactories = {
                 }
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Repeat(
                 this.decorators,
                 this.iterations,
@@ -192,7 +192,7 @@ const ASTNodeFactories = {
                 throw "a flip node must have a single child";
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Flip(
                 this.decorators,
                 this.children[0].createNodeInstance(namedRootNodeProvider, visitedBranches.slice())
@@ -205,7 +205,7 @@ const ASTNodeFactories = {
         conditionFunction: "",
         conditionArguments: [],
         validate: function (depth) {},
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Condition(
                 this.decorators,
                 this.conditionFunction,
@@ -219,14 +219,14 @@ const ASTNodeFactories = {
         duration: null,
         longestDuration: null,
         validate: function (depth) {
-            // A wait node must have a positive duration. 
+            // A wait node must have a positive duration.
             if (this.duration < 0) {
                 throw "a wait node must have a positive duration";
             }
 
             // There is validation to carry out if a longest duration was defined.
             if (this.longestDuration) {
-                // A wait node must have a positive longest duration. 
+                // A wait node must have a positive longest duration.
                 if (this.longestDuration < 0) {
                     throw "a wait node must have a positive longest duration if one is defined";
                 }
@@ -237,7 +237,7 @@ const ASTNodeFactories = {
                 }
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Wait(
                 this.decorators,
                 this.duration,
@@ -255,7 +255,7 @@ const ASTNodeFactories = {
             return new Action(
                 this.decorators,
                 this.actionName,
-		this.actionsArguments,
+                this.actionsArguments,
             );
         }
     })
@@ -319,7 +319,7 @@ export default function buildRootASTNodes(tokens) {
                 stack.push(node.children);
                 break;
 
-            case "BRANCH": 
+            case "BRANCH":
                 // Create a BRANCH AST node.
                 node = ASTNodeFactories.BRANCH();
 
@@ -329,7 +329,7 @@ export default function buildRootASTNodes(tokens) {
                 // We must have arguments defined, as we require a branch name argument.
                 if (tokens[0] !== "[") {
                     throw "expected single branch name argument";
-                } 
+                }
 
                 // The branch name will be defined as a node argument.
                 const branchArguments = getArguments(tokens);
@@ -340,10 +340,10 @@ export default function buildRootASTNodes(tokens) {
                     node.branchName = branchArguments[0];
                 } else {
                     throw "expected single branch name argument";
-                } 
+                }
                 break;
 
-            case "SELECTOR": 
+            case "SELECTOR":
                 // Create a SELECTOR AST node.
                 node = ASTNodeFactories.SELECTOR();
 
@@ -413,7 +413,7 @@ export default function buildRootASTNodes(tokens) {
                 stack.push(node.children);
                 break;
 
-            case "CONDITION": 
+            case "CONDITION":
                 // Create a CONDITION AST node.
                 node = ASTNodeFactories.CONDITION();
 
@@ -423,12 +423,12 @@ export default function buildRootASTNodes(tokens) {
                 // We must have arguments defined, as we require a condition function name argument.
                 if (tokens[0] !== "[") {
                     throw "expected single condition name argument";
-                } 
+                }
 
                 // The condition name will be defined as a node argument.
-                const [conditionFunction, ...conditionArguments] = getArguments(tokens);
-                node.conditionFunction = conditionFunction;
-                node.conditionArguments = conditionArguments || [];
+                const tokenArguments = getArguments(tokens);
+                node.conditionFunction = tokenArguments.pop();
+                node.conditionArguments = tokenArguments || [];
 
                 // Try to pick any decorators off of the token stack.
                 node.decorators = getDecorators(tokens);
@@ -522,18 +522,18 @@ export default function buildRootASTNodes(tokens) {
                 // We must have arguments defined, as we require an action name argument.
                 if (tokens[0] !== "[") {
                     throw "expected single action name argument";
-                } 
+                }
 
                 // The action name will be defined as a node argument.
-                const [actionName, ...actionArguments] = getArguments(tokens);
-                node.actionName = actionName;
-                node.actionArguments = actionArguments || [];
+                const tokenArguments = getArguments(tokens);
+                node.actionName = tokenArguments.pop();
+                node.actionArguments = tokenArguments || [];
 
                 // Try to pick any decorators off of the token stack.
                 node.decorators = getDecorators(tokens);
                 break;
 
-            case "}": 
+            case "}":
                 // The '}' character closes the current scope.
                 stack.pop();
                 break;
@@ -553,7 +553,7 @@ export default function buildRootASTNodes(tokens) {
     };
 
     // Start node validation from the definition root.
-    validateASTNode({ 
+    validateASTNode({
         children: stack[0],
         validate: function (depth) {
             // We must have at least one node defined as the definition scope, which should be a root node.
@@ -601,12 +601,12 @@ function popAndCheck(tokens, expected) {
 
     // We were expecting another token.
     if (popped === undefined) {
-        throw "unexpected end of definition"; 
+        throw "unexpected end of definition";
     }
 
     // If an expected token was defined, was it the expected one?
     if (expected && popped.toUpperCase() !== expected.toUpperCase()) {
-        throw "unexpected token found on the stack. Expected '" + expected + "' but got '" + popped + "'"; 
+        throw "unexpected token found on the stack. Expected '" + expected + "' but got '" + popped + "'";
     }
 
     // Return the popped token.
@@ -668,12 +668,12 @@ function getArguments(tokens, argumentValidator, validationFailedMessage) {
  * @returns An array od decorators defined by any directly following tokens.
  */
 function getDecorators(tokens) {
-	// Create an array to hold any decorators found. 
+	// Create an array to hold any decorators found.
 	const decorators = [];
-  
+
     // Keep track of names of decorators that we have found on the token stack, as we cannot have duplicates.
     const decoratorsFound = [];
-  
+
     // Try to get the decorator factory for the next token.
     let decoratorFactory = DecoratorFactories[(tokens[0] || "").toUpperCase()];
 
@@ -689,20 +689,22 @@ function getDecorators(tokens) {
         // The decorator definition should consist of the tokens 'NAME', '(', 'ARGUMENT' and ')'.
         popAndCheck(tokens, tokens[0].toUpperCase());
         popAndCheck(tokens, "(");
-	// store decorator name, condition, and condition arguments
-        const decoratorArgument = [];
-        let arg = popAndCheck(tokens);
+
+        // store decorator name, condition, and condition arguments
+        const decoratorArguments = [];
+        const decoratorName = popAndCheck(tokens);
+        let arg = popAndCheck(tokens)
         while (arg !== ")") {
-            decoratorArgument.push(arg);
+            decoratorArguments.push(arg);
             arg = popAndCheck(tokens)
         }
 
         // Create the decorator and add it to the array of decorators found.
-        decorators.push(decoratorFactory(decoratorArgument));
+        decorators.push(decoratorFactory(decoratorName, decoratorArguments));
 
         // Try to get the next decorator name token, as there could be multiple.
         decoratorFactory = DecoratorFactories[(tokens[0] || "").toUpperCase()];
     }
-  
+
 	return decorators;
 };


### PR DESCRIPTION
- [x] Store Decorator Condition Arguments: Store more than just the Condition name.
- [x] Action Arguments: de-structure name and arguments. store arguments for later.
- [x] When called, Send Action Arguments as well
- [x] Upgrade all Guards to accept condition arguments and pass them along when calling condition
- [x] remove trailing spaces
- [x] annotate major changes with 👁️ 